### PR TITLE
feat: add get inner state methods to modal state, impl default for modal state

### DIFF
--- a/examples/modal/src/main.rs
+++ b/examples/modal/src/main.rs
@@ -17,6 +17,7 @@ enum Message {
     OkButtonPressed,
 }
 
+#[derive(Default)]
 struct ModalExample {
     open_state: button::State,
     modal_state: modal::State<ModalState>,
@@ -33,11 +34,7 @@ impl Sandbox for ModalExample {
     type Message = Message;
 
     fn new() -> Self {
-        ModalExample {
-            open_state: button::State::new(),
-            modal_state: modal::State::new(ModalState::default()),
-            last_message: None,
-        }
+        Self::default()
     }
 
     fn title(&self) -> String {

--- a/src/native/modal.rs
+++ b/src/native/modal.rs
@@ -112,7 +112,7 @@ where
 }
 
 /// The state of the modal.
-#[derive(Debug)]
+#[derive(Debug, Default)]
 pub struct State<S> {
     /// The visibility of the [`Modal`](Modal) overlay.
     show: bool,

--- a/src/native/modal.rs
+++ b/src/native/modal.rs
@@ -134,6 +134,16 @@ impl<S> State<S> {
     pub fn show(&mut self, b: bool) {
         self.show = b;
     }
+
+    /// Get a mutable reference to the inner state data.
+    pub fn inner_mut(&mut self) -> &mut S {
+        &mut self.state
+    }
+
+    /// Get a reference to the inner state data.
+    pub const fn inner(&self) -> &S {
+        &self.state
+    }
 }
 
 impl<'a, S, Content, Message, Renderer> Widget<Message, Renderer>


### PR DESCRIPTION
This PR adds `inner` and `inner_mut` methods to `modal::State` for geting a (mutable) reference to the inner state data of a modal and implements `Default` trait for `modal::State` if inner state implements `Default` too.